### PR TITLE
投稿1削除対応

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ gem "omniauth-twitter2"
 
 gem "importmap-rails"
 
-gem 'aws-sdk-s3', '~> 1.100'
+gem "aws-sdk-s3", "~> 1.100"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -54,6 +54,11 @@ class PostsController < ApplicationController
     redirect_to posts_path, notice: "投稿を削除しました"
   end
 
+  def cleanup
+    Post.find(1).destroy
+    render plain: "deleted"
+  end
+
   private
 
   def set_post

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -7,7 +7,7 @@ class Post < ApplicationRecord
   validate :images_count_within_limit
 
   private
-  
+
   def images_presence
     errors.add(:images, "を1枚以上追加してください") unless images.attached?
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,4 +7,6 @@ Rails.application.routes.draw do
   root "pages#home"
   resources :posts, only: %i[index new create show edit destroy update]
   get "up" => "rails/health#show", as: :rails_health_check
+
+  get "/cleanup_once", to: "posts#cleanup"
 end


### PR DESCRIPTION
B2導入前にテスト投稿した画像が、renderデプロイ時、エラーとなったため削除する。